### PR TITLE
Update topicpull-minitoc.xsl to include all topic types

### DIFF
--- a/com.synopsys.mini-toc/topicpull-minitoc.xsl
+++ b/com.synopsys.mini-toc/topicpull-minitoc.xsl
@@ -20,7 +20,7 @@
 
       <!-- create the list of links (we reuse the topicpull processing to get the link text) -->
       <xsl:variable name="links" as="element()*">
-        <xsl:apply-templates select="ancestor::topic[1]/related-links/linklist[@role = 'mini-toc']/link"/>
+         <xsl:apply-templates select="ancestor::*[contains(@class, 'topic/topic')][1]/related-links/linklist[@role = 'mini-toc']/link"/>
       </xsl:variable>
       <xsl:if test="count($links) > 0">
         <ul class="- topic/ul " outputclass="mini-toc-list">


### PR DESCRIPTION
Adding the functionality to show all content types in the list, not only topic nodes.