### PR TITLE
Add extra HTML classes for better support with bootstrap: listgroup i…

### DIFF
--- a/com.synopsys.mini-toc/topicpull-minitoc.xsl
+++ b/com.synopsys.mini-toc/topicpull-minitoc.xsl
@@ -23,9 +23,9 @@
          <xsl:apply-templates select="ancestor::*[contains(@class, 'topic/topic')][1]/related-links/linklist[@role = 'mini-toc']/link"/>
       </xsl:variable>
       <xsl:if test="count($links) > 0">
-        <ul class="- topic/ul " outputclass="mini-toc-list">
+      	<ul class="- topic/ul " outputclass="mini-toc-list list-group">
           <xsl:for-each select="$links">
-            <li class="- topic/li ">
+          	<li class="- topic/li list-group-item">
               <xref class="- topic/xref ">
                 <xsl:apply-templates select="@href | @type"/>
                 <xsl:value-of select="./linktext"/>  <!-- this should always resolve for valid links -->


### PR DESCRIPTION
In case of interest: I added extra classes to `ul` and `li `to create a bootstrap `listgroup ` instead of simple list.
If I recall well, you also use OxygenXML Webhelp and might be interested.

